### PR TITLE
Implement the foreground service for the Go library

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,23 +1,28 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="xyz.coronanet">
-    <uses-permission android:name="android.permission.INTERNET" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.INTERNET" />
 
-    <application
-      android:name=".MainApplication"
-      android:label="@string/app_name"
-      android:icon="@mipmap/ic_launcher"
-      android:roundIcon="@mipmap/ic_launcher_round"
-      android:allowBackup="false"
-      android:theme="@style/AppTheme">
-      <activity
-        android:name=".MainActivity"
-        android:label="@string/app_name"
-        android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
-        android:windowSoftInputMode="adjustResize">
-        <intent-filter>
-            <action android:name="android.intent.action.MAIN" />
-            <category android:name="android.intent.category.LAUNCHER" />
-        </intent-filter>
-      </activity>
-      <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
-    </application>
+  <application
+    android:name=".MainApplication"
+    android:label="Corona Network"
+    android:icon="@mipmap/ic_launcher"
+    android:roundIcon="@mipmap/ic_launcher_round"
+    android:allowBackup="false"
+    android:theme="@style/AppTheme">
+    <service
+      android:name=".GatewayService"
+      android:exported="false"
+    />
+    <activity
+      android:name=".MainActivity"
+      android:label="Corona Network"
+      android:configChanges="keyboard|keyboardHidden|orientation|screenSize"
+      android:windowSoftInputMode="adjustResize">
+      <intent-filter>
+          <action android:name="android.intent.action.MAIN" />
+          <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+    </activity>
+    <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+  </application>
 </manifest>

--- a/android/app/src/main/java/io/ipsn/ghostbridge/GhostBridge.java
+++ b/android/app/src/main/java/io/ipsn/ghostbridge/GhostBridge.java
@@ -83,7 +83,7 @@ public class GhostBridge {
           public Response intercept(Chain chain) throws IOException {
             // If the request is not addressed the bridge, execute directly
             Request original = chain.request();
-            if (!original.url().host().equals("ghost-bridge")) {
+            if (!original.url().host().equals("corona-network")) {
               return chain.proceed(original);
             }
             // Request sent to the ghost-bridge, redirect to localhost

--- a/android/app/src/main/java/xyz/coronanet/GatewayService.java
+++ b/android/app/src/main/java/xyz/coronanet/GatewayService.java
@@ -1,0 +1,130 @@
+// rn-coronanet - Coronavirus social distancing network
+// Copyright (c) 2020 Péter Szilágyi. All rights reserved.
+
+package xyz.coronanet;
+
+import android.app.Service;
+import android.app.Notification;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.os.Build;
+import android.os.IBinder;
+import android.R;
+
+import xyz.coronanet.Bridge;
+import xyz.coronanet.GatewayStatus;
+import io.ipsn.ghostbridge.GhostBridge;
+
+// GatewayService is the foreground Android service that acts as the gateway into
+// the P2P corona network.
+public class GatewayService extends Service {
+  // bridge is the API server library implemented in Go that React Native can call
+  // directly via HTTP.
+  private Bridge bridge;
+
+  @Override
+  public void onCreate() {
+    // Create the corona network gateway, don't do anything with it
+    try {
+      bridge = new Bridge(getFilesDir().getPath());
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
+  @Override
+  public int onStartCommand(Intent intent, int flags, int startId) {
+    // Create a notification channel to talk between the service and the UI
+    NotificationManager manager = getSystemService(NotificationManager.class);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+      NotificationChannel channel = new NotificationChannel(
+        "CoronaNetworkServiceChannel",
+        "Corona Network Service Channel",
+        NotificationManager.IMPORTANCE_DEFAULT
+      );
+      channel.setSound(null, null);
+      manager.createNotificationChannel(channel);
+    }
+    // Tell Android to convert this service into a foreground one
+    Intent notificationIntent = new Intent(this, MainActivity.class);
+    PendingIntent notificationPendingIntent = PendingIntent.getActivity(this, 0, notificationIntent, 0);
+
+    Notification.Builder notifier = new Notification.Builder(this, "CoronaNetworkServiceChannel");
+    Notification notification = notifier
+      .setSmallIcon(R.drawable.sym_def_app_icon)
+      .setSound(null)
+      .setContentIntent(notificationPendingIntent)
+      .build();
+
+    startForeground(1, notification);
+
+    try {
+      bridge.enableGateway();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    // Start a background thread to periodically update the notification status
+    Thread updater = new Thread() {
+      public void run() {
+        while (true) {
+          try {
+            GatewayStatus status = bridge.gatewayStatus();
+            if (!status.getEnabled()) {
+              notifier.setContentTitle("You are currently offline");
+              notifier.setContentText("You won't get or send updates");
+            } else if (!status.getConnected()) {
+              notifier.setContentTitle("You are currently connecting");
+              notifier.setContentText("Waiting for mobile or WiFi network");
+            } else {
+              notifier.setContentTitle("You are currently online");
+
+              long   ingress    = status.getIngress();
+              String ingressStr = ingress < 1024L ? ingress + " B"
+                : ingress <= 0xfffccccccccccccL >> 40 ? String.format("%.1f KiB", ingress / 0x1p10)
+                : ingress <= 0xfffccccccccccccL >> 30 ? String.format("%.1f MiB", ingress / 0x1p20)
+                : ingress <= 0xfffccccccccccccL >> 20 ? String.format("%.1f GiB", ingress / 0x1p30)
+                : ingress <= 0xfffccccccccccccL >> 10 ? String.format("%.1f TiB", ingress / 0x1p40)
+                : ingress <= 0xfffccccccccccccL ? String.format("%.1f PiB", (ingress >> 10) / 0x1p40)
+                : String.format("%.1f EiB", (ingress >> 20) / 0x1p40);
+
+              long   egress    = status.getEgress();
+              String egressStr = egress < 1024L ? egress + " B"
+                : egress <= 0xfffccccccccccccL >> 40 ? String.format("%.1f KiB", egress / 0x1p10)
+                : egress <= 0xfffccccccccccccL >> 30 ? String.format("%.1f MiB", egress / 0x1p20)
+                : egress <= 0xfffccccccccccccL >> 20 ? String.format("%.1f GiB", egress / 0x1p30)
+                : egress <= 0xfffccccccccccccL >> 10 ? String.format("%.1f TiB", egress / 0x1p40)
+                : egress <= 0xfffccccccccccccL ? String.format("%.1f PiB", (egress >> 10) / 0x1p40)
+                : String.format("%.1f EiB", (egress >> 20) / 0x1p40);
+
+              notifier.setContentText("Downloaded " + ingressStr + ", uploaded " + egressStr);
+            }
+            manager.notify(1, notifier.build());
+
+            Thread.sleep(5000);
+          } catch (Exception e) { }
+        }
+      }
+    };
+    updater.start();
+
+    // A new user interface attached to the gateway, inject the certs
+    try {
+      GhostBridge.init(bridge.port(), bridge.cert(), bridge.token());
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    // If we get killed, after returning from here, restart
+    return START_STICKY;
+  }
+
+  @Override
+  public IBinder onBind(Intent intent) {
+      return null;
+  }
+
+  @Override
+  public void onDestroy() {
+  }
+}

--- a/android/app/src/main/java/xyz/coronanet/MainApplication.java
+++ b/android/app/src/main/java/xyz/coronanet/MainApplication.java
@@ -1,17 +1,19 @@
 package xyz.coronanet;
 
 import android.app.Application;
+import android.app.Notification;
+import android.app.PendingIntent;
 import android.content.Context;
+import android.content.Intent;
+
 import com.facebook.react.PackageList;
 import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
+
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
-
-import xyz.coronanet.Bridge;
-import io.ipsn.ghostbridge.GhostBridge;
 
 public class MainApplication extends Application implements ReactApplication {
   private final ReactNativeHost mReactNativeHost =
@@ -47,12 +49,8 @@ public class MainApplication extends Application implements ReactApplication {
     SoLoader.init(this, /* native exopackage */ false);
     initializeFlipper(this); // Remove this line if you don't want Flipper enabled
 
-    try {
-      Bridge bridge = new Bridge();
-      GhostBridge.init(bridge.port(), bridge.cert(), bridge.token());
-    } catch (Exception e) {
-      e.printStackTrace();
-    }
+    Intent intent = new Intent(this, GatewayService.class);
+    startForegroundService(intent);
   }
 
   /**

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">CoronaNet</string>
-</resources>

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.1",
   "private": true,
   "config": {
-    "coronanet_archive": "https://github.com/coronanet/go-coronanet/releases/download/v0.0.1/coronanet.aar",
-    "coronanet_sha256": "6271325364a44672e219bd9fb3c57928dd1f4a9fb9dcec97f4580fec48f7ceab"
+    "coronanet_archive": "https://github.com/coronanet/go-coronanet/releases/download/v0.0.2/coronanet.aar",
+    "coronanet_sha256": "eab083c7aa453a5d1f8cc42c7e3f0c4abc1250f69b5db0c311eebb830a859a8c"
   },
   "scripts": {
     "android-archive-check": "echo \"$npm_package_config_coronanet_sha256 android/app/libs/coronanet.aar\" | sha256sum --check",
     "android-archive":       "yarn run android-archive-check || (curl -L $npm_package_config_coronanet_archive --create-dirs --output android/app/libs/coronanet.aar && yarn run android-archive-check)",
-    "android":               "yarn run android-archive && react-native run-android",
+    "android":               "yarn run android-archive && yarn run android-nosync",
+    "android-nosync":        "react-native run-android",
 
     "ios": "react-native run-ios",
     "start": "react-native start",


### PR DESCRIPTION
This PR finally implements a Go backend integration into an Android foreground service. Long story short, it allows running networking Go code in the background indefinitely, without murdering it along with the app. :tada: 

If anyone's following my path, to run a Go process in Android, you need to:

- Request the `FOREGROUND_SERVICE` permission for your application.
- Create a class that implements `Service` and register it in your Android manifest.
- In your UI activity (or wherever), launch with it `startForegroundService`.
- In your services's start method, set up a system notification
  - On newer Android's you also need an explicit notification channel
  - Android will kill your service unless you show the user that it exists
  - Tell Android to move your service to the foreground `startForeground`
- Voila, do whatever you want, it will stay alive (I think/hope)

Fixes https://github.com/coronanet/rn-coronanet/issues/3